### PR TITLE
Add f-clap package

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@
 
 [command_args](http://flibs.sourceforge.net/command_args.html): automatically handles the command-line arguments that are passed to the program, by Arjen Markus
 
+[f-clap](https://gitlab.com/bwearley/f-clap): Fortran Command Line Argument Parser, by Brian Earley
+
 [f90getopt](https://github.com/haniibrahim/f90getopt): getopt()- and getopt_long()-like functionality (similar to the C-functions) for Fortran 90, by Hani Andreas Ibrahim, based on code by Mark Gates
 
 [fArgParse](https://github.com/Goddard-Fortran-Ecosystem/fArgParse): command line argument parsing for Fortran, part of the [Goddard Fortran Ecosystem](https://github.com/Goddard-Fortran-Ecosystem)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added f-clap (Fortran Command Line Argument Parser) to the Command Line Parsing section in the README, expanding the list of available command-line tools for Fortran developers. This update provides developers with an additional resource for implementing argument parsing functionality in their Fortran projects. Includes proper author attribution and reference links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->